### PR TITLE
v0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Fluentd output plugin to post message to xymon
 
 Install gem
 
-    fluent-gem install fluent-plugin-xymon
+````
+fluent-gem install fluent-plugin-xymon
+````
 
 ## config
 
@@ -14,10 +16,57 @@ Install gem
     config_param :xymon_server, :string
     config_param :xymon_port, :string, :default => '1984'
     config_param :color, :string, :default => 'green'
-    config_param :host, :string
-    config_param :column, :string
+    config_param :hostname, :string
+    config_param :testname, :string
     config_param :name_key, :string
+    config_param :custom_determine_color_code, :string, :default => nil
 ````
+
+### example
+
+<store>
+  type xymon
+  xymon_server                127.0.0.1
+  xymon_port                  1984
+  color                       green
+  hostname                    web-server-01
+  testname                    CPU
+  name_key                    CPUUtilization
+  custom_determine_color_code if value.to_i > 90; 'red'; else 'green'; end
+</store>
+
+## config_param :custom_determine_color_code
+
+set ruby code of determinate color to custom_determine_color_code.
+
+### Parameter
+
+time, record, value
+
+### Example
+
+#### everytime 'green'
+
+````
+custom_determine_color_code return 'green'
+````
+
+#### if value > 90 then 'red' else 'green'
+
+````
+custom_determine_color_code if  value > 90; 'red'; else 'green'; end
+````
+### config_param :color
+
+ignore :color if custom_determine_color_code is exist and valid.
+use :color if custom_determine_color_code is noting or invalid
+
+### If raise some exception
+
+server didn't respond
+
+- use config color value
+- write warn log
 
 ## Contributing
 
@@ -26,3 +75,7 @@ Install gem
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+## releases
+2013/08/09 0.0.0 1st release
+2013/08/10 0.0.1 https://github.com/bash0C7/fluent-plugin-xymon/pull/1

--- a/fluent-plugin-xymon.gemspec
+++ b/fluent-plugin-xymon.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-xymon"
-  spec.version       = '0.0.0'
+  spec.version       = '0.0.1'
   spec.authors       = ["bash0C7"]
   spec.email         = ["koshiba+github@4038nullpointer.com"]
   spec.description   = "Fluentd output plugin to post message to xymon"

--- a/lib/fluent/plugin/out_xymon.rb
+++ b/lib/fluent/plugin/out_xymon.rb
@@ -10,8 +10,8 @@ module Fluent
     config_param :xymon_server, :string
     config_param :xymon_port, :string, :default => '1984'
     config_param :color, :string, :default => 'green'
-    config_param :host, :string
-    config_param :column, :string
+    config_param :hostname, :string
+    config_param :testname, :string
     config_param :name_key, :string
 
     def configure(conf)
@@ -42,7 +42,7 @@ module Fluent
 
     def build_message time, value
       body = "#{@name_key}=#{value}"
-      message = "status #{@host}.#{@column} #{@color} #{Time.at(time)} #{@column} #{body}\n\n#{body}"
+      message = "status #{@hostname}.#{@testname} #{@color} #{Time.at(time)} #{@testname} #{body}\n\n#{body}"
 
       message
     end

--- a/lib/fluent/plugin/out_xymon.rb
+++ b/lib/fluent/plugin/out_xymon.rb
@@ -19,7 +19,12 @@ module Fluent
       super
 
       @custom_determine_color = nil
-      @custom_determine_color = lambda {|time, record, value| eval(@custom_determine_color_code)} if @custom_determine_color_code
+      begin
+        @custom_determine_color = eval("lambda {|time, record, value| #{@custom_determine_color_code}}") if @custom_determine_color_code
+      rescue Exception
+        raise Fluent::ConfigError, "custom_determine_color_code: #{$!.class}, '#{$!.message}'"
+      end
+        
     end
 
     def start

--- a/spec/lib/fluent/plugin/out_xymon_spec.rb
+++ b/spec/lib/fluent/plugin/out_xymon_spec.rb
@@ -5,9 +5,9 @@ describe do
     %[
       xymon_server 127.0.0.1
       xymon_port   1984
-      color         red
-      host         host1
-      column       column1
+      color        red
+      hostname     host1
+      testname     column1
       name_key     field1
     ]
   }
@@ -33,12 +33,12 @@ describe do
     end
 
     context do
-      subject {driver.instance.host}
+      subject {driver.instance.hostname}
       it{should == 'host1'}
     end
 
     context do
-      subject {driver.instance.column}
+      subject {driver.instance.testname}
       it{should == 'column1'}
     end
 
@@ -52,7 +52,7 @@ describe do
   describe 'build_message' do
     context do
       subject {driver.instance.build_message(0, 50)}
-      it{should == "status #{driver.instance.host}.#{driver.instance.column} #{driver.instance.color} #{Time.at(0)} #{driver.instance.column} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
+      it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{driver.instance.color} #{Time.at(0)} #{driver.instance.testname} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
     end
   end
   

--- a/spec/lib/fluent/plugin/out_xymon_spec.rb
+++ b/spec/lib/fluent/plugin/out_xymon_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe do
+  let(:driver) {
+    Fluent::Test::OutputTestDriver.new(Fluent::XymonOutput, 'test.metrics').configure(config)
+  }
+
   let(:config) {
     %[
       xymon_server 127.0.0.1
@@ -10,10 +14,6 @@ describe do
       testname     column1
       name_key     field1
     ]
-  }
-
-  let(:driver) {
-    Fluent::Test::OutputTestDriver.new(Fluent::XymonOutput, 'test.metrics').configure(config)
   }
 
   describe 'config' do
@@ -47,25 +47,115 @@ describe do
       it{should == 'field1'}
     end
 
+    describe 'custom_determine_color_code' do
+      context 'not_exist' do
+        subject {driver.instance.custom_determine_color_code}
+        it{should be_nil}
+      end
+
+      context 'exist' do
+        let(:config) {
+          %[
+            xymon_server 127.0.0.1
+            xymon_port   1984
+            color        red
+            hostname     host1
+            testname     column1
+            name_key     field1
+            custom_determine_color_code return 'green'
+          ]
+        }
+
+        subject {driver.instance.custom_determine_color_code}
+        it{should == "return 'green'"}
+      end
+    end
   end
 
   describe 'build_message' do
-    context do
-      subject {driver.instance.build_message(0, 50)}
+    let(:record) {[]}
+    context 'empty custom_determine_color_code' do
+      subject {driver.instance.build_message(0, record, 50)}
       it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{driver.instance.color} #{Time.at(0)} #{driver.instance.testname} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
     end
+
+    context 'valid custom_determine_color_code' do
+      let(:config) {
+        %[
+          xymon_server 127.0.0.1
+          xymon_port   1984
+          color        red
+          hostname     host1
+          testname     column1
+          name_key     field1
+          custom_determine_color_code if value.to_i > 90; 'red'; else 'green'; end
+        ]
+      }
+
+      subject {driver.instance.build_message(0, record, 50)}
+      it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{'green'} #{Time.at(0)} #{driver.instance.testname} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
+    end
+
+    context 'invalid syntax custom_determine_color_code' do
+      let(:config) {
+        %[
+          xymon_server 127.0.0.1
+          xymon_port   1984
+          color        red
+          hostname     host1
+          testname     column1
+          name_key     field1
+          custom_determine_color_code (><)
+        ]
+      }
+
+      subject {driver.instance.build_message(0, record, 50)}
+      it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{driver.instance.color} #{Time.at(0)} #{driver.instance.testname} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
+    end
+
   end
   
   describe 'emit' do
-
     let(:posted) {
       d = driver
       mock(IO).popen("nc '#{d.instance.xymon_server}' '#{d.instance.xymon_port}'", 'w').times 1
       d.emit({ 'field1' => 50, 'otherfield' => 99})
-      d.run
+      d.run  
     }
 
-    context do
+    context 'empty custom_determine_color_code' do
+      subject {posted}
+      it{should_not be_nil}
+    end
+
+    context 'valid custom_determine_color_code' do
+      let(:config) {
+        %[
+          xymon_server 127.0.0.1
+          xymon_port   1984
+          color        red
+          hostname     host1
+          testname     column1
+          name_key     field1
+          custom_determine_color_code if value.to_i > 90; 'red'; else 'green'; end
+        ]
+      }
+      subject {posted}
+      it{should_not be_nil}
+    end
+
+    context 'invalid syntax custom_determine_color_code' do
+      let(:config) {
+        %[
+          xymon_server 127.0.0.1
+          xymon_port   1984
+          color        red
+          hostname     host1
+          testname     column1
+          name_key     field1
+          custom_determine_color_code (><)
+        ]
+      }
       subject {posted}
       it{should_not be_nil}
     end

--- a/spec/lib/fluent/plugin/out_xymon_spec.rb
+++ b/spec/lib/fluent/plugin/out_xymon_spec.rb
@@ -53,7 +53,7 @@ describe do
         it{should be_nil}
       end
 
-      context 'exist' do
+      context 'valid syntax' do
         let(:config) {
           %[
             xymon_server 127.0.0.1
@@ -69,17 +69,41 @@ describe do
         subject {driver.instance.custom_determine_color_code}
         it{should == "return 'green'"}
       end
+
+      context 'invalid syntax' do
+        let(:config) {
+          %[
+            xymon_server 127.0.0.1
+            xymon_port   1984
+            color        red
+            hostname     host1
+            testname     column1
+            name_key     field1
+            custom_determine_color_code (><)
+          ]
+        }
+
+        subject {lambda{driver.instance.custom_determine_color_code}}
+        it{should raise_error(Fluent::ConfigError)}
+      end
+
     end
   end
 
   describe 'build_message' do
-    let(:record) {[]}
+    let(:name_key) {'field1'}
+    
+    let(:record) {{ name_key => 50, 'otherfield' => 99}}
+    let(:time) {0}
+    let(:value) {record[name_key]}
+
+    let(:built) {driver.instance.build_message(time, record, value)}
     context 'empty custom_determine_color_code' do
-      subject {driver.instance.build_message(0, record, 50)}
+      subject {built}
       it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{driver.instance.color} #{Time.at(0)} #{driver.instance.testname} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
     end
 
-    context 'valid custom_determine_color_code' do
+    context 'exist custom_determine_color_code' do
       let(:config) {
         %[
           xymon_server 127.0.0.1
@@ -87,39 +111,37 @@ describe do
           color        red
           hostname     host1
           testname     column1
-          name_key     field1
-          custom_determine_color_code if value.to_i > 90; 'red'; else 'green'; end
+          name_key     #{name_key}
+          custom_determine_color_code #{custom_determine_color_code}
         ]
       }
 
-      subject {driver.instance.build_message(0, record, 50)}
-      it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{'green'} #{Time.at(0)} #{driver.instance.testname} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
+      context 'valid custom_determine_color_code' do
+        let(:custom_determine_color_code) {"if value.to_i > 90; 'red'; else 'green'; end"}
+
+        subject {built}
+        it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{'green'} #{Time.at(time)} #{driver.instance.testname} #{driver.instance.name_key}=#{value}\n\n#{driver.instance.name_key}=#{value}"}
+      end
+
+      context 'invalid syntax custom_determine_color_code' do
+        let(:custom_determine_color_code) {'Fluent::XymonOutput::UNDEFINED_CONST'}
+
+        subject {
+          mock($log).warn("raises exception: NameError, 'uninitialized constant #{custom_determine_color_code}', 'Fluent::XymonOutput::UNDEFINED_CONST', '#{time}', '#{record.to_s}', '#{record[name_key]}'").times 1
+          built
+        }
+        it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{driver.instance.color} #{Time.at(time)} #{driver.instance.testname} #{driver.instance.name_key}=#{value}\n\n#{driver.instance.name_key}=#{value}"}
+      end
     end
-
-    context 'invalid syntax custom_determine_color_code' do
-      let(:config) {
-        %[
-          xymon_server 127.0.0.1
-          xymon_port   1984
-          color        red
-          hostname     host1
-          testname     column1
-          name_key     field1
-          custom_determine_color_code (><)
-        ]
-      }
-
-      subject {driver.instance.build_message(0, record, 50)}
-      it{should == "status #{driver.instance.hostname}.#{driver.instance.testname} #{driver.instance.color} #{Time.at(0)} #{driver.instance.testname} #{driver.instance.name_key}=50\n\n#{driver.instance.name_key}=50"}
-    end
-
   end
   
   describe 'emit' do
+    let(:record) {{ 'field1' => 50, 'otherfield' => 99}}
+    let(:time) {0}
     let(:posted) {
       d = driver
       mock(IO).popen("nc '#{d.instance.xymon_server}' '#{d.instance.xymon_port}'", 'w').times 1
-      d.emit({ 'field1' => 50, 'otherfield' => 99})
+      d.emit(record, Time.at(time))
       d.run  
     }
 
@@ -128,7 +150,8 @@ describe do
       it{should_not be_nil}
     end
 
-    context 'valid custom_determine_color_code' do
+    context 'exist custom_determine_color_code' do
+    let(:name_key) {'field1'}
       let(:config) {
         %[
           xymon_server 127.0.0.1
@@ -136,28 +159,27 @@ describe do
           color        red
           hostname     host1
           testname     column1
-          name_key     field1
-          custom_determine_color_code if value.to_i > 90; 'red'; else 'green'; end
+          name_key     #{name_key}
+          custom_determine_color_code #{custom_determine_color_code}
         ]
       }
-      subject {posted}
-      it{should_not be_nil}
-    end
 
-    context 'invalid syntax custom_determine_color_code' do
-      let(:config) {
-        %[
-          xymon_server 127.0.0.1
-          xymon_port   1984
-          color        red
-          hostname     host1
-          testname     column1
-          name_key     field1
-          custom_determine_color_code (><)
-        ]
-      }
-      subject {posted}
-      it{should_not be_nil}
+      context 'valid custom_determine_color_code' do
+        let(:custom_determine_color_code) {"if value.to_i > 90; 'red'; else 'green'; end"}
+      
+        subject {posted}
+        it{should_not be_nil}
+      end
+
+      context 'invalid syntax custom_determine_color_code' do
+        let(:custom_determine_color_code) {'Fluent::XymonOutput::UNDEFINED_CONST'}
+
+        subject {
+          mock($log).warn("raises exception: NameError, 'uninitialized constant Fluent::XymonOutput::UNDEFINED_CONST', 'Fluent::XymonOutput::UNDEFINED_CONST', '#{time}', '#{record.to_s}', '#{record[name_key]}'").times 1
+          posted        
+        }
+        it{should_not be_nil}
+      end
     end
   end
 end

--- a/spec/lib/fluent/plugin/out_xymon_spec.rb
+++ b/spec/lib/fluent/plugin/out_xymon_spec.rb
@@ -69,20 +69,5 @@ describe do
       subject {posted}
       it{should_not be_nil}
     end
-
-    #    context do
-    #      subject {posted[:data][:message]}
-    #      it{should =~ "status #{driver.instance.host}.#{driver.instance.column} #{driver.instance.color} [^\n]+\n\n#{driver.instance.name_key}=50"}
-    #    end
-    #
-    #    context do
-    #      subject {posted[:data][:xymon_server]}
-    #      it{should == driver.instance.xymon_server}
-    #    end
-    #
-    #    context do
-    #      subject {posted[:data][:xymon_port]}
-    #      it{should == driver.instance.xymon_port}
-    #    end
   end
 end


### PR DESCRIPTION
## Rename config params
- host -> hostname
- column -> testname
  
  (see: http://hobbit.math.cnrs.fr/hobbit/help/manpages/man1/bb.1.html)
## Add config param
-  custom_determine_color_code

set ruby code of determinate color to config_param :custom_determine_color_code
### Parameter

time, record, value
### Example
#### everytime 'green'

```
custom_determine_color_code return 'green'
```
#### if value > 90 then 'red' else 'green'

```
custom_determine_color_code if  value > 90; 'red'; else 'green'; end
```
#### If raise some exception

server didn't respond
- use config color value
- write warn log
